### PR TITLE
[codex] document skill architecture optimization

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,8 @@ flowchart TD
     Arch --> Lookup[metadata-lookup-workflow.md]
     Lookup --> Conversion[metadata-conversion-flow.md]
     Conversion --> Semantic[semantic-analysis-run.md]
-    Semantic --> Interaction[skill-interaction-design.md]
+    Semantic --> Optimization[skill-architecture-optimization-20260702.md]
+    Optimization --> Interaction[skill-interaction-design.md]
     Interaction --> Invocation[skill-invocation-policy.md]
     Invocation --> Privacy[PRIVACY.md / TERMS.md]
 ```
@@ -29,10 +30,11 @@ flowchart TD
 | `metadata-lookup-workflow.md` | 分析师 / Agent builder | 解释为什么需求理解阶段先 search/context，而不是扫完整 YAML |
 | `metadata-conversion-flow.md` | 贡献者 / 架构维护者 | 解释 YAML、index、context、registry、OSI 的转换关系 |
 | `metadata-skill-consolidation.md` | 维护者 | 解释 metadata skill 为什么是统一入口 |
+| `skill-architecture-optimization-20260702.md` | 维护者 / Agent builder | 解释 skills 从分散入口收敛到 active skillset、共享能力、探索流程和统一路由的优化方案 |
 | `update-guide.md` | 用户 / LLM / Codex | 先更新插件本体，再按最新架构逐层检查和更新项目内容物 |
 | `architecture.md` | 所有用户 / 贡献者 | 三核架构、文件职责、公开仓库边界 |
-| `skill-interaction-design.md` | 维护者 / Agent builder | RealAnalyst skill 的调用关系、数据契约和运行时序 |
-| `skill-invocation-policy.md` | Agent builder / skill 维护者 | 规定什么时候自动调用、什么时候只提示、什么时候不调用，避免用户每次手动点名 skill |
+| `skill-interaction-design.md` | 维护者 / Agent builder | RealAnalyst active skills、legacy 兼容入口、数据契约和运行时序 |
+| `skill-invocation-policy.md` | Agent builder / skill 维护者 | 规定什么时候自动调用、什么时候确认、什么时候只回答，避免误升级成正式分析或取数 |
 | `skillset-audit-report.md` | 维护者 / 发布前检查者 | 记录本轮 skillset 填写、脚本、模板、交付物和流程完整性审查结论 |
 | `semantic-analysis-run.md` | 分析师 / 产品经理 | 解释从 metadata 到报告验证的端到端链路 |
 | `validation-report.md` | 维护者 / 发布前检查者 | 记录发布前验证结果、已知限制和复查建议 |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@ RealAnalyst 是平台无关的 metadata-first 分析执行系统。Codex skills 
 
 | Core | 管什么 | 主要路径 |
 | --- | --- | --- |
-| Metadata Core | 业务含义、definition state、evidence relation、index/context builder | `metadata/`、`skills/metadata/`、`skills/metadata-search/` |
+| Metadata Core | 业务含义、definition state、evidence relation、index/context builder | `metadata/`、`skills/metadata/` |
 | Runtime Registry Core | source registry、connector metadata、filter / parameter / source group | `runtime/registry.db`、`runtime/`、`skills/data-export/` |
 | Job Core | 单次分析状态、artifact index、feedback、verification artifacts | `jobs/{SESSION_ID}/`、`skills/analysis-run/`、`skills/report-verify/` |
 
@@ -41,7 +41,7 @@ flowchart LR
         Router -->|unregistered| MetadataEntry["RA:metadata<br/>minimum registration"]
         Router -->|ready| Run["RA:analysis-run<br/>formal analysis"]
         MetadataEntry --> Run
-        Run --> Plan["analysis-plan"]
+        Run --> Plan["Phase 0.2 planning<br/>inside analysis-run"]
         Run --> Export
         Export --> Fusion["artifact-fusion<br/>source group merge"]
         Fusion --> Profile["data-profile"]

--- a/docs/llm-next-steps.md
+++ b/docs/llm-next-steps.md
@@ -125,7 +125,7 @@ TABLEAU_PAT_SECRET=your-personal-access-token-secret
 帮我验证这份报告是否可交付，重点检查数据来源、口径状态、结论证据和待复核项。
 ```
 
-流程内 skill 不作为普通用户第一层入口：`RA:analysis-plan`、`RA:data-export`、`RA:data-profile`、`RA:report` 通常由 `RA:analysis-run` 编排。`RA:metadata-search` 只在用户明确想查字段/指标/术语/dataset 是否已维护时使用；`RA:artifact-fusion`、`RA:analysis-reference` 是高级/流程内工具；`RA:reference-lookup` 仅作 legacy compatibility entrypoint。
+流程内和共享 skill 不作为普通用户第一层入口：planning 已并入 `RA:analysis-run` Phase 0.2；`RA:data-export`、`RA:data-profile`、`RA:report` 通常由 `RA:analysis-run` 编排，或由 dashboard、探索、refine 流程带着明确输出路径调用。字段、指标、术语和 dataset 检索统一进入 `RA:metadata search/catalog/context`；`RA:metadata-search`、`RA:analysis-plan`、`RA:analysis-reference`、`RA:reference-lookup` 仅作 legacy compatibility entrypoint。
 
 ## 安装检查
 

--- a/docs/semantic-analysis-run.md
+++ b/docs/semantic-analysis-run.md
@@ -26,7 +26,7 @@ LLM 不是真实事实源。LLM 可以起草定义、组织证据、生成计划
 6. `metadata status --dataset-id ...` 确认 metadata_yaml、metadata_index、runtime_registry 和 export_ready。
 7. 需要长期口径说明时，用户主动调用 `RA:metadata-report`；最小注册完成后只提示，不自动生成。
 8. 数据已准备好后，进入 `RA:analysis-run` 做正式完整分析。它不吞掉 metadata 注册流程。
-9. `RA:analysis-run` 内部编排 `RA:analysis-plan`、`RA:data-export`、`RA:data-profile`、LLM 分析、`RA:report`、`RA:report-verify`。
+9. `RA:analysis-run` 内部编排 Phase 0.2 planning、`RA:data-export`、`RA:data-profile`、LLM 分析、`RA:report`、`RA:report-verify`；legacy `RA:analysis-plan` 不再作为日常 active 入口。
 10. 报告生成后进入 `RA:report-verify`，重点检查推断口径、review 标记和结果可复核性。
 11. 分析中如发现字段定义不清、指标口径待修或证据不足，只记录到 job feedback，不修改正式 YAML。
 12. 用户主动调用 `RA:metadata-refine`，把 job feedback、profile、CSV 探查和用户反馈整理为 `metadata/sources/refine/` 参考材料。

--- a/docs/skill-architecture-optimization-20260702.md
+++ b/docs/skill-architecture-optimization-20260702.md
@@ -1,0 +1,183 @@
+# RealAnalyst Skill 架构优化说明（2026-07-02）
+
+本文档记录 RealAnalyst skills 的一次架构收敛：把分散的搜索、规划和参考能力合并回 owner skill，把 `data-export` 和 `data-profile` 抽象为共享能力，并补齐轻量数据探索、dashboard-oriented metadata context 和统一路由 hook 的设计约束。
+
+这份文档是 docs-first 说明，面向维护者、Agent builder 和需要评审 skill 改动的人。它不包含私有业务数据，也不要求读者访问 analyst-workspace 的本地任务目录。
+
+---
+
+## 背景问题
+
+旧设计的问题不是能力不够，而是入口太碎：
+
+| 问题 | 表现 | 影响 |
+| --- | --- | --- |
+| 搜索入口分散 | `metadata` 与 `metadata-search` 同时存在 | 用户和 Agent 不确定该从维护入口还是检索入口开始。 |
+| 分析规划独立成 skill | `analysis-run` 需要再调 `analysis-plan` 和 `analysis-reference` | 正式分析链路被拆得过细，产物 owner 变弱。 |
+| data-export/data-profile 被描述为流程内阶段 | 它们实际被分析、dashboard、探索和 refine 共同需要 | 文档限制了复用场景，也让输出路径约定不清。 |
+| 缺少轻量探索路径 | “先看看数据”容易被升级为正式分析 job | 产生过重 artifacts，降低试探成本。 |
+| dashboard 与 metadata 连接不足 | 图表设计容易从页面模块开始，而不是从字段和指标语义开始 | 后续真实数据绑定、筛选器和汇总口径更容易漂移。 |
+| hook 路由过窄 | dashboard gate 容易误注入普通分析或 metadata 任务 | 上下文噪声变大，Agent 容易套错 workflow。 |
+
+---
+
+## 优化目标
+
+| 目标 | 判断标准 |
+| --- | --- |
+| Skill 数量收敛 | 日常 active skillset 从 13 个收敛到 10 个核心入口。 |
+| Owner 清晰 | 搜索归 `metadata`，planning 归 `analysis-run`，references 归 `analysis-run/references`。 |
+| 共享能力独立 | `data-export` 和 `data-profile` 同时服务分析、dashboard、探索和 refine。 |
+| 探索路径轻量 | 快速预览不创建 job，不写正式报告，产物放临时目录。 |
+| Dashboard metadata-first | goal decomposer 先读取 dashboard-oriented context，再设计指标、筛选器和图表。 |
+| 路由精准 | hook 根据 dashboard、exploration、analysis、metadata 四类场景注入不同上下文。 |
+
+---
+
+## Active Skillset
+
+### 共享层
+
+| Skill | 变化 | 责任 |
+| --- | --- | --- |
+| `RA:metadata` | 合并 `metadata-search` 的 search/catalog 能力 | 搜索、catalog、注册、维护、validate、index、context、registry sync。 |
+| `RA:data-export` | 从 analysis-run 内部阶段改为项目共享能力 | 受控取数、字段白名单、manifest、source lineage。 |
+| `RA:data-profile` | 从 analysis-run 内部阶段改为项目共享能力 | 缺失、异常、类型、分布和数据质量画像。 |
+
+### 分析层
+
+| Skill | 变化 | 责任 |
+| --- | --- | --- |
+| `RA:analysis-run` | 合并 `analysis-plan`，内置 Phase 0.2 planning | 正式分析编排、计划确认、分析 artifacts、连续追问。 |
+| `RA:report` | 保持 | 基于证据生成报告。 |
+| `RA:report-verify` | 保持 | 验证报告可交付性。 |
+| `RA:metadata-refine` | 保持，并可调用共享取数/画像能力 | 生成 metadata 修正参考材料。 |
+
+### Dashboard 层
+
+| Skill | 变化 | 责任 |
+| --- | --- | --- |
+| `dashboard-goal-decomposer` | 新增 metadata context 准备阶段 | 读取 `metadata context --dashboard-oriented`，拆解目标、指标、维度、筛选器和 chart intent。 |
+| `dashboard-prototype-planner` | 保持三段式中间层 | 输出 prototype、layout、view-model contract 和 handoff prompt。 |
+| `dashboard-implementation-builder` | 明确调用共享 `data-export` 和 `data-profile` | 构建真实数据 dashboard，完成 binding audit、browser QA 和 review gates。 |
+
+---
+
+## Deprecated 与迁移路径
+
+| Deprecated skill | 新入口 | 迁移说明 |
+| --- | --- | --- |
+| `RA:metadata-search` | `RA:metadata` | `search`、`catalog`、`context` 都由 metadata 统一承担。 |
+| `RA:analysis-plan` | `RA:analysis-run` Phase 0.2 | 正式分析会自动执行 planning；高级维护者不需要单独点名。 |
+| `RA:analysis-reference` | `skills/analysis-run/references/` | 框架、模板和 planning reference 改为普通参考文件读取。 |
+
+建议保留 deprecated skill 文件一段时间，文件内只写迁移提示、兼容说明和新入口，不再继续扩展能力。
+
+---
+
+## 共享能力调用约定
+
+### `RA:data-export`
+
+| 调用方 | 输出位置 | 约束 |
+| --- | --- | --- |
+| `RA:analysis-run` | `jobs/{SESSION_ID}/data/` | 必须来自用户确认后的 analysis plan。 |
+| `dashboard-implementation-builder` | `project/<dashboard-name>/warehouse/data/` | 支撑 DWD/DWS/ADS 或 view-model 构建。 |
+| 数据探索流程 | `/tmp/exploration_*/` | 默认限制 1000 行以内，标注为临时样本。 |
+| `RA:metadata-refine` | refine workbench 或 job 证据目录 | 只用于探查真实字段和值，不直接写 YAML。 |
+
+核心约束保持不变：registry-first、字段白名单、manifest 记录、受控取数、source lineage 可追溯。
+
+### `RA:data-profile`
+
+| 调用方 | 输出位置 | 约束 |
+| --- | --- | --- |
+| `RA:analysis-run` | `jobs/{SESSION_ID}/profile/` | 作为正式分析证据。 |
+| `dashboard-implementation-builder` | dashboard project evidence 或 warehouse profile 目录 | 检查 DWD/ADS 是否支撑页面绑定和筛选器。 |
+| 数据探索流程 | `/tmp/exploration_*/profile/` | 快速判断字段类型、空值率、异常和候选问题。 |
+| `RA:metadata-refine` | refine reference pack | 为字段定义、枚举、异常和口径缺口提供证据。 |
+
+---
+
+## 数据探索流程
+
+探索流程用于“先看看”“有哪些字段”“数据大概什么情况”这类低承诺请求。
+
+| 步骤 | 行动 | 产物 |
+| --- | --- | --- |
+| 定位数据源 | `RA:metadata search/catalog` | 候选 dataset、字段、指标和 review 标记。 |
+| 快速取数 | `RA:data-export` 限制样本量 | `/tmp/exploration_*/sample.csv` 或等价临时导出。 |
+| 快速画像 | `RA:data-profile` | `/tmp/exploration_*/profile/profile.json`。 |
+| 输出摘要 | 聊天回复 | 字段列表、样本摘要、分布概览、质量信号、候选问题。 |
+
+探索流程不创建 `jobs/{SESSION_ID}/`，不写正式报告，不沉淀 metadata，不替代可交付分析。它的升级路径只有三种：进入 `RA:analysis-run`、进入 dashboard loop、进入 `RA:metadata-refine`。
+
+---
+
+## Dashboard-oriented Metadata Context
+
+Dashboard 设计需要比普通分析 context 多一些面向图表和控件的提示。
+
+| 字段 | 用途 |
+| --- | --- |
+| `chart_intent` | 判断指标适合趋势、对比、结构、分布、明细或诊断。 |
+| `filter_role` | 判断字段适合作为全局筛选、局部筛选、分组维度或参数。 |
+| `aggregation_safety` | 提醒可加总、不可加总、需去重、需按粒度约束的指标。 |
+| `view_model_readiness` | 判断字段是否足以进入 dashboard view model，是否需要补口径或真实数据探查。 |
+
+`dashboard-goal-decomposer` 应先读 dashboard-oriented context，再输出 chart contract 和 open questions。`dashboard-implementation-builder` 在真实数据阶段调用共享 `data-export` 和 `data-profile`，并用 binding audit 验证页面控件、模块和数据槽位。
+
+---
+
+## Unified Route Hook
+
+统一路由 hook 的目标不是替代 skill，而是让上下文注入更精准。
+
+| Route | 触发场景 | 注入内容 |
+| --- | --- | --- |
+| dashboard | dashboard、看板、cockpit、Antigravity HTML、binding audit | Dashboard Loop、三段式 skill 顺序、mock 替换、readiness gates。 |
+| exploration | 先看看、快速预览、有哪些字段、数据结构 | 探索约束、临时目录、样本限制、升级路径。 |
+| analysis | 正式分析、报告、归因、诊断、对比 | `RA:analysis-run` Phase 0-4、确认点、共享取数画像能力。 |
+| metadata | 注册、字段定义、指标口径、registry、context | `RA:metadata` 统一入口、validate/index/sync/context、refine 边界。 |
+
+优先级建议为 dashboard > exploration > analysis > metadata。dashboard 的写入检查和 stop gate 只在明确 dashboard route 时启用，避免普通任务被 dashboard gate 干扰。
+
+---
+
+## 验证建议
+
+| 验证面 | 检查方式 | 通过标准 |
+| --- | --- | --- |
+| 文档一致性 | 搜索 docs 中旧入口描述 | `metadata-search`、`analysis-plan`、`analysis-reference` 均标注为 legacy 或迁移路径。 |
+| Skill 合并 | 检查 `metadata/SKILL.md` 与 `analysis-run/SKILL.md` | search/catalog/context 归 metadata；planning 归 analysis-run。 |
+| 共享能力 | 检查 `data-export/SKILL.md` 与 `data-profile/SKILL.md` | 四类调用方都有说明，输出路径清楚。 |
+| 探索流程 | 运行一次小样本导出和画像 | 不创建 job，输出临时 profile 和探索摘要。 |
+| Dashboard | 运行 dashboard goal 到 implementation 的 contract 检查 | 使用 dashboard-oriented context、真实数据、binding audit 和 browser QA。 |
+| Hook | 静态或单元测试 route detection | 四类 route 能正确识别，dashboard gate 不误触发普通分析。 |
+
+本轮本地验证包记录为 23 个检查点通过。公开仓库 PR 如只更新 docs，可把验证范围限定为 markdown 链接、术语一致性和不引入私有路径。
+
+---
+
+## 对维护者的落地顺序
+
+| 顺序 | 动作 | 原因 |
+| --- | --- | --- |
+| 1 | 先更新 docs 和调用策略 | 让 reviewer 明确架构目标和迁移方向。 |
+| 2 | 合并 `metadata-search` 到 `metadata` | 先解决最常见入口分裂。 |
+| 3 | 合并 `analysis-plan` 到 `analysis-run` Phase 0.2 | 让正式分析链路恢复单一 owner。 |
+| 4 | 将 `data-export` 和 `data-profile` 改为共享能力 | 支撑分析、dashboard、探索和 refine。 |
+| 5 | 补探索流程和 dashboard-oriented context | 覆盖轻量预览和可视化链路。 |
+| 6 | 引入 unified route hook | 在流程稳定后再做上下文注入自动化。 |
+
+---
+
+## PR 审查重点
+
+| 审查点 | 需要确认 |
+| --- | --- |
+| 是否只改 docs | 若 PR 标注 docs-first，不应夹带源码、私有任务产物或生成数据。 |
+| 是否诚实描述实现状态 | 已落地、目标架构、legacy 兼容和后续代码同步要分清。 |
+| 是否保留迁移路径 | 旧入口用户能知道下一步该用哪个 skill。 |
+| 是否避免过度自动化 | Hook 只注入上下文和 gate，不替代 skill owner。 |
+| 是否保护 source of truth | metadata、registry、job 的边界不因 skill 合并而变模糊。 |

--- a/docs/skill-interaction-design.md
+++ b/docs/skill-interaction-design.md
@@ -1,20 +1,8 @@
 # RealAnalyst Skills 交互与产物详细设计
 
-本文档描述 RealAnalyst 中 14 个 skill 之间的调用关系、数据传递契约、产物规范和运行时序。用户第一层入口只有 `RA:getting-started`、`RA:metadata`、`RA:analysis-run`；其它 skill 是补充入口、流程内能力、高级工具或 legacy compatibility entrypoint。
+本文档描述 RealAnalyst 的当前目标交互模型：10 个 active skills 承担日常工作流，legacy compatibility skills 仅保留迁移和旧入口兼容。设计目标是减少用户需要记忆的入口，同时把 metadata、取数、画像、分析、报告和验证之间的数据契约讲清楚。
 
----
-
-## 目录
-
-- [设计原则](#设计原则)
-- [Skill 分类](#skill-分类)
-- [主链路时序](#主链路时序)
-- [每个 Skill 的详细接口](#每个-skill-的详细接口)
-- [Skill 间数据契约](#skill-间数据契约)
-- [连续分析（多轮）](#连续分析多轮)
-- [辅助 Skill 触发条件](#辅助-skill-触发条件)
-- [错误处理与降级](#错误处理与降级)
-- [产物生命周期](#产物生命周期)
+相关架构优化背景见 [skill-architecture-optimization-20260702.md](skill-architecture-optimization-20260702.md)。
 
 ---
 
@@ -22,603 +10,171 @@
 
 | 原则 | 说明 |
 | --- | --- |
-| **三核边界** | Metadata 管“含义”，Runtime Registry 管“能不能取”，Job 管“这次实际用了什么” |
-| **正式分析入口** | `RA:analysis-run` 是正式分析入口，按 Phase 0–5 调度流程内 skill，但不自动吞掉 metadata 注册流程 |
-| **单 Session 单 Job** | 同一会话内只允许一个 `jobs/{SESSION_ID}/` 目录 |
-| **Append-only** | 报告和 `analysis.json` 在连续分析中只追加不重写 |
-| **产物路径从索引读取** | 禁止猜测文件名，必须从 `export_summary` / `artifact_index` 获取实际路径 |
-| **用户确认先于执行** | Plan 确认、新增数据源确认、报告交付确认 — 至少保留一次停顿 |
-| **Schema 驱动** | 所有结构化产物有 JSON Schema，skill 间通过 schema 约定数据格式 |
-| **环境先固定** | 正式任务先由 `RA:getting-started` doctor 输出 Python、skill base、registry path 和 readiness；后续 skill 使用该摘要，不自由猜环境 |
-| **展示不改 identity** | CSV/header/display name 需求留在 export/report 层；`metadata/datasets/*.yaml` 的 `fields[].name` 只由 `RA:metadata` 在维护任务中修改 |
+| 三核边界 | Metadata 管业务含义，Runtime Registry 管能不能取，Job 管本次实际用了什么。 |
+| 主入口收敛 | 普通用户优先记住 `RA:getting-started`、`RA:metadata`、`RA:analysis-run`。 |
+| Metadata-first | 选择数据集、字段、指标、筛选器、SQL 口径和报告结论前，先查 metadata，再查 live 数据。 |
+| 共享能力复用 | `RA:data-export` 和 `RA:data-profile` 是项目共享能力，可被分析、dashboard、探索和 metadata refine 调用。 |
+| 计划先于正式取数 | 正式分析必须先展示计划、数据源、筛选口径和风险，确认后再导出。 |
+| 轻量探索不升级成正式 job | 只想看字段、样本和质量概况时走探索流程，不创建 `jobs/{SESSION_ID}/`。 |
+| 产物 owner 清晰 | 每个 artifact 能回到唯一 owner skill 或明确的共享能力调用方。 |
+| 兼容入口有迁移方向 | legacy skills 可以保留文件和提示，但新的编排默认不依赖它们。 |
 
 ---
 
 ## Skill 分类
 
-### 用户第一层入口
+### Active Skills
 
-| Skill | 定位 |
-| --- | --- |
-| `RA:getting-started` | 轻量向导 + skill router + minimal status check |
-| `RA:metadata` | 注册/维护数据源、字段、指标、口径；未注册但想分析时先走这里 |
-| `RA:analysis-run` | 数据已准备好后的正式完整分析入口 |
-
-### 常见补充入口
-
-| Skill | 定位 |
-| --- | --- |
-| `RA:metadata-report` | 查看数据集长期口径说明 |
-| `RA:metadata-refine` | 分析结束后归档口径问题和真实数据探查材料 |
-| `RA:report-verify` | 检查已有报告是否可交付 |
-
-### 流程内主链路（按执行顺序）
-
-```
-getting-started → metadata → analysis-run
-                                ├── analysis-plan   (Phase 0)
-                                ├── data-export     (Phase 1)
-                                ├── data-profile    (Phase 2)
-                                ├── [LLM 分析]      (Phase 3)
-                                ├── report          (Phase 4)
-                                └── report-verify   (Phase 5)
-```
-
-### 流程内 / 辅助 / 高级 / 兼容
-
-| Skill | 角色 | 触发时机 |
+| 层级 | Skill | 定位 |
 | --- | --- | --- |
-| `analysis-plan` | 流程内 | `RA:analysis-run` 规划阶段 |
-| `data-export` | 流程内 | `RA:analysis-run` 取数阶段 |
-| `data-profile` | 流程内 | `RA:analysis-run` 画像阶段 |
-| `report` | 流程内 | `RA:analysis-run` 报告阶段 |
-| `metadata-search` | 辅助 | 只想查字段/指标/术语/dataset 是否已维护 |
-| `artifact-fusion` | 高级 | source group 内多源合并，在 data-export 后、data-profile 前 |
-| `analysis-reference` | 高级/流程内 | analysis-plan 选框架/模板时 |
-| `reference-lookup` | 兼容 | legacy compatibility entrypoint |
+| 入口层 | `RA:getting-started` | 初次使用、状态检查、下一步 skill routing。 |
+| 共享层 | `RA:metadata` | 搜索、catalog、注册、维护、validate、index、context、registry sync 的统一入口。 |
+| 共享层 | `RA:data-export` | 受控取数能力，服务正式分析、dashboard、探索和 metadata refine。 |
+| 共享层 | `RA:data-profile` | 数据画像能力，服务正式分析、dashboard、探索和 metadata refine。 |
+| 分析层 | `RA:analysis-run` | 正式分析入口，内置 planning、取数、画像、分析、报告和验证编排。 |
+| 分析层 | `RA:report` | 基于 plan、profile、analysis 和证据生成 Markdown 报告。 |
+| 分析层 | `RA:report-verify` | 检查报告证据链、推断口径、数据来源和交付 readiness。 |
+| 分析层 | `RA:metadata-refine` | 把 job 反馈、profile 和真实数据探查整理成 metadata 修正参考材料。 |
+| 仪表盘层 | `dashboard-goal-decomposer` | 把 dashboard 目标拆成问题树、指标、维度、筛选器和 chart intent。 |
+| 仪表盘层 | `dashboard-prototype-planner` | 把 goal/chart/filter contract 转成 prototype、layout 和 Antigravity handoff。 |
+| 仪表盘层 | `dashboard-implementation-builder` | 基于真实数据、view model、binding audit 和 browser QA 构建 dashboard。 |
+
+> 仪表盘三段式是一个层级组合，因此 active skillset 的业务能力数按 10 个核心入口统计：共享层 3 个、分析层 4 个、仪表盘层 3 个。
+
+### Legacy Compatibility Skills
+
+| Legacy skill | 新路径 | 兼容策略 |
+| --- | --- | --- |
+| `RA:metadata-search` | `RA:metadata search/catalog/context` | 保留迁移提示；新流程直接调用 `RA:metadata`。 |
+| `RA:analysis-plan` | `RA:analysis-run` Phase 0.2 | Planning 作为正式分析内置阶段。 |
+| `RA:analysis-reference` | `skills/analysis-run/references/` | 不再作为独立 skill 调用，改为读取 references。 |
+| `RA:reference-lookup` | `RA:metadata` 或 `RA:analysis-run` references | 仅保留旧脚本和旧 prompt 兼容。 |
 
 ---
 
-## 主链路时序
+## 主链路
 
-### 完整流程（单轮）
+### 正式分析
 
 ```mermaid
 sequenceDiagram
     actor User
     participant AR as RA:analysis-run
-    participant AP as RA:analysis-plan
-    participant RL as RA:analysis-reference
-    participant MS as RA:metadata-search
+    participant M as RA:metadata
     participant EX as RA:data-export
     participant DP as RA:data-profile
     participant RPT as RA:report
     participant RV as RA:report-verify
+    participant REF as RA:metadata-refine
 
-    rect rgb(240, 248, 255)
-    Note over AR: Phase 0 — 需求理解与规划
-    User->>AR: 业务问题
-    AR->>AR: Step 0.1: 需求画像
-    Note right of AR: → normalized_request.json
-    AR->>AP: Step 0.2: /skill RA:analysis-plan
-    AP->>RL: 查框架/模板定义
-    RL-->>AP: JSON 配置结果
-    AP->>MS: 查指标/字段定义
-    MS-->>AP: JSON 检索结果
-    AP-->>AR: → analysis_plan.md (10 章)
-    AR-->>User: 展示计划，等待确认
-    User-->>AR: 确认 plan
-    end
-
-    rect rgb(255, 248, 240)
-    Note over AR: Phase 1 — 受控取数
-    AR->>EX: /skill RA:data-export
-    Note right of EX: 查 registry → 导出<br/>→ CSV + export_summary<br/>→ acquisition_log
-    EX-->>AR: CSV 就绪
-    end
-
-    rect rgb(240, 255, 240)
-    Note over AR: Phase 2 — 数据画像
-    AR->>DP: /skill RA:data-profile
-    Note right of DP: 读 export_summary 推导 CSV<br/>→ manifest.json<br/>→ profile.json
-    DP-->>AR: 画像完成
-    end
-
-    rect rgb(255, 255, 240)
-    Note over AR: Phase 3 — 分析（LLM）
-    AR->>AR: 读 profile + plan + CSV
-    AR->>AR: 执行分析逻辑
-    Note right of AR: → analysis.json<br/>→ 汇总_*.csv / 交叉_*.csv<br/>→ analysis_journal.md
-    end
-
-    rect rgb(248, 240, 255)
-    Note over AR: Phase 4 — 报告撰写
-    AR->>RPT: /skill RA:report
-    RPT->>RL: 查模板/术语
-    RL-->>RPT: 模板配置
-    Note right of RPT: 读 plan + profile + analysis<br/>→ 报告_{主题}_{时间}.md
-    RPT-->>AR: 报告完成
-    end
-
-    rect rgb(255, 240, 240)
-    Note over AR: Phase 5 — 交付门禁
-    AR->>RV: /skill RA:report-verify
-    Note right of RV: 读 CSV + analysis.json + 报告<br/>→ verification.json
-    RV-->>AR: 门禁结果
-    end
-
-    AR-->>User: 交付报告 + verification
+    User->>AR: 提出正式业务分析问题
+    AR->>M: search/catalog/context 定位数据源和口径
+    M-->>AR: metadata context pack
+    AR->>AR: Phase 0.2 生成 analysis_plan.md
+    AR-->>User: 展示计划、数据源、筛选条件和风险
+    User-->>AR: 确认执行
+    AR->>EX: 受控取数
+    EX-->>AR: CSV、export_summary、acquisition_log
+    AR->>DP: 数据画像
+    DP-->>AR: profile manifest、profile.json
+    AR->>AR: LLM 分析并写入 analysis.json
+    AR->>RPT: 生成报告
+    RPT-->>AR: report.md
+    AR->>RV: 交付验证
+    RV-->>AR: verification.json
+    AR-->>User: 报告、验证结果和待复核项
+    AR->>REF: 如有口径缺口，整理 refine reference pack
 ```
 
-### 连续分析（多轮追问）
+### 轻量数据探索
 
 ```mermaid
-sequenceDiagram
-    actor User
-    participant AR as RA:analysis-run
-
-    Note over AR: 第 1 轮完成
-
-    User->>AR: 追问（同一会话）
-    Note over AR: 复用同一 jobs/{SESSION_ID}/<br/>Phase 3: 读已有数据 + 补分析
-    Note right of AR: analysis.json: 追加 findings<br/>报告: 追加章节<br/>analysis_journal: 追加日志
-
-    alt 当前数据够用
-        AR->>AR: 直接分析 → 追加报告
-    else 需要补同源数据
-        AR->>AR: 记录原因 → 补导出 → 补画像 → 分析
-    else 需要新数据源
-        AR-->>User: 说明原因，等待确认
-        User-->>AR: 确认新增
-        AR->>AR: 导出 → 画像 → 分析
-    end
-
-    AR-->>User: 追加后的报告
+flowchart LR
+    U[用户想先看看数据] --> M[RA:metadata search/catalog]
+    M --> EX[RA:data-export limit 1000]
+    EX --> DP[RA:data-profile quick profile]
+    DP --> S[探索摘要]
+    S --> A{下一步}
+    A -->|深入分析| AR[RA:analysis-run]
+    A -->|可视化展示| DB[Dashboard Loop]
+    A -->|维护口径| REF[RA:metadata-refine]
 ```
 
----
+探索产物默认放在 `/tmp/exploration_*`，只输出字段列表、样本、分布概览、质量信号和候选问题。它不创建 job、不写正式报告、不沉淀长期 metadata。
 
-## 每个 Skill 的详细接口
+### Dashboard Loop
 
-### RA:getting-started
-
-| 项目 | 说明 |
-| --- | --- |
-| **触发条件** | 首次使用、不知道准备什么、想确认数据源类型 |
-| **输入** | 用户目标、当前项目 metadata / registry / dataset 状态、数据源描述 |
-| **输出** | 最小状态检查结果、一条可复制的下一步 `/skill` 指令 |
-| **下游** | `RA:metadata`、`RA:analysis-run`、`RA:metadata-report`、`RA:metadata-refine`、`RA:report-verify` |
-| **脚本** | 无（纯对话引导） |
-
-边界：不创建正式 analysis job，不取数，不生成业务报告，不自动注册正式 metadata。用户想分析但数据未注册时，推荐先走 `RA:metadata` 做最小可分析注册。
-
-只读环境检查：
-
-```bash
-python3 skills/getting-started/scripts/doctor.py --intent start
+```mermaid
+flowchart LR
+    G[dashboard-goal-decomposer] --> P[dashboard-prototype-planner]
+    P --> B[dashboard-implementation-builder]
+    M[RA:metadata context --dashboard-oriented] --> G
+    EX[RA:data-export] --> B
+    DP[RA:data-profile] --> B
+    B --> QA[binding audit + browser QA + review gates]
 ```
 
-doctor 输出固定 JSON 摘要：`python_command`、`skill_base_dir`、`registry_path`、`duckdb_path`、依赖状态、metadata / registry / export readiness 和 `recommended_next_skill`。它不写任何项目文件。
-
-### RA:metadata
-
-| 项目 | 说明 |
-| --- | --- |
-| **触发条件** | 注册数据集、维护字段/指标/术语、生成 context、Tableau/DuckDB onboarding |
-| **输入** | dataset YAML、source evidence、关键词、`metadata/sources/refine/{refine_id}/` 参考材料 |
-| **输出** | validate 结果、index JSONL、search 结果、context pack |
-| **下游** | `RA:analysis-plan`（via context pack）、`RA:data-export`（via registry） |
-| **核心脚本** | `skills/metadata/scripts/metadata.py {validate,index,search,context}` |
-| **分层** | sources → dictionaries → mappings → datasets → index/context → registry |
-
-**关键产物**：
-
-| 产物 | 路径 | 用途 |
-| --- | --- | --- |
-| validate 结果 | stdout JSON | 检查 YAML 是否满足字段、指标、证据、review 契约 |
-| index | `metadata/index/*.jsonl` | 低 token 检索（analysis-plan 用） |
-| context pack | `metadata/osi/<dataset_id>/context.md` | 给 analysis-plan 的最小上下文 |
-| registry sync | `runtime/registry.db` | data-export 的数据源注册表与运行时 lookup tables |
-
-### RA:metadata-refine
-
-| 项目 | 说明 |
-| --- | --- |
-| **触发条件** | 分析 job 或用户反馈暴露字段定义、指标口径、证据不足、真实数据与 YAML 不一致 |
-| **输入** | `metadata_feedback.jsonl`、profile、正式 CSV、用户反馈 |
-| **输出** | `metadata/sources/refine/{refine_id}/` 参考材料，包含 `refine_followup.md` |
-| **下游** | `RA:metadata` 基于参考材料修正式 YAML |
-| **核心脚本** | `skills/metadata-refine/scripts/{collect_feedback,probe_data,build_reference_pack,archive_reference_pack}.py` |
-
-`RA:metadata-refine` 不直接改 YAML，不同步 registry；分析流程只把问题记录到 job，再由 refine 生成参考材料。
-
-### RA:analysis-plan
-
-| 项目 | 说明 |
-| --- | --- |
-| **触发条件** | 取数前需要正式计划；analysis-run Step 0.2 自动调用 |
-| **输入** | `normalized_request.json` + metadata context pack |
-| **输出** | `.meta/analysis_plan.md`（10 章） |
-| **下游** | analysis-run（Phase 1+）、report |
-| **依赖** | `RA:analysis-reference`（查框架、模板）、`RA:metadata-search`（查指标、字段） |
-
-**10 章输出规范**：
-
-1. 数据源概述
-2. 场景分类与分析框架锁定（`selected_framework_id`）
-3. 业务假设清单
-4. 异常判定标准
-5. 下钻路径设计
-6. 框架配置引用（via analysis-reference）
-7. 目标拆解（goals + artifacts）
-8. 报告模板锁定（`selected_report_template`）
-9. 数据采集方案
-10. 质量检查点
-
-**降级处理**：
-
-- 在 `RA:analysis-run` 编排下：`normalized_request.json` 不存在时报错终止
-- 独立调用时：向用户追问 5 项必填信息 → 自行生成最小版 `normalized_request.json`
-
-### RA:analysis-run
-
-| 项目 | 说明 |
-| --- | --- |
-| **触发条件** | 数据已准备好的完整分析任务 |
-| **输入** | 用户问题 + 已注册 metadata / registry |
-| **输出** | 完整 job 目录 |
-| **角色** | **正式分析入口** — 自身不做取数/画像/报告，而是调度流程内 skill |
-
-边界：如果缺少最小可分析 metadata 或 runtime registry readiness，先交给 `RA:metadata`；分析中发现口径问题只记录 job feedback，不直接改正式 YAML。
-
-分析入口不得把字段展示问题升级成 metadata 维护：CSV 表头中文化、报告显示名调整、导出列名翻译交给 `RA:data-export` / `RA:report`，不改 dataset `fields[].name`。
-
-**Phase 分解**：
-
-| Phase | 动作 | 调用 Skill | 产出 |
-| --- | --- | --- | --- |
-| 0.1 | 需求画像 | （自身） | `normalized_request.json` |
-| 0.2 | 分析规划 | `RA:analysis-plan` | `analysis_plan.md` |
-| 1 | 受控取数 | `RA:data-export` | CSV + export_summary + acquisition_log |
-| 2 | 数据画像 | `RA:data-profile` | manifest.json + profile.json |
-| 3 | LLM 分析 | （自身） | `analysis.json` + 汇总/交叉 CSV + journal |
-| 4 | 报告撰写 | `RA:report` | `报告_{主题}_{时间}.md` |
-| 5 | 交付门禁 | `RA:report-verify` | `verification.json` |
-
-**硬约束**：
-- 一会话一 job
-- 报告只追加不重写
-- 至少一次用户确认停顿
-- 禁止默认任何行业/公司/主体
-
-### RA:data-export
-
-| 项目 | 说明 |
-| --- | --- |
-| **触发条件** | 已锁定 source，需要正式导出 |
-| **输入** | registry source id + filters/fields + SESSION_ID |
-| **输出** | 见下表 |
-| **上游** | analysis-run Phase 1、metadata（registry） |
-| **下游** | data-profile（via export_summary → CSV 路径） |
-
-边界：本 skill 解决 CSV/header/display name 输出问题，但不修改 `metadata/datasets/*.yaml`。如果发现 metadata 定义确实缺失，只写 job/refine feedback 或提示用户进入 `RA:metadata-refine` / `RA:metadata`。
-
-**Tableau vs DuckDB 产物对比**：
-
-| 产物 | Tableau | DuckDB |
-| --- | --- | --- |
-| 正式 CSV | `data/交叉_<source>.csv` | `data/<output-name>.csv` |
-| 导出摘要 | `export_summary.json` | `duckdb_export_summary.json` |
-| 语义上下文 | `source_context.json` ✅ | ❌ 不生成（用 metadata context pack 替代） |
-| 上下文注入 | `context_injection.md` ✅ | ❌ 不生成 |
-| 审计日志 | `acquisition_log.jsonl` | `acquisition_log.jsonl` |
-| 产物索引 | `artifact_index.json` | `artifact_index.json` |
-
-### RA:data-profile
-
-| 项目 | 说明 |
-| --- | --- |
-| **触发条件** | 导出数据后，分析前做画像 |
-| **输入** | 正式 CSV（从 export_summary 自动推导） |
-| **输出** | `profile/manifest.json` + `profile/profile.json` |
-| **上游** | data-export |
-| **下游** | analysis-run Phase 3、report |
-
-**manifest.json 内容**：schema、列名映射、lineage、profile_summary
-
-**profile.json 内容**：字段语义角色（metric/dimension）、基数、缺失率、分布信号、质量评分
-
-### RA:report
-
-| 项目 | 说明 |
-| --- | --- |
-| **触发条件** | 分析完成后写报告 |
-| **输入** | analysis_plan.md + profile + analysis + artifact_index + 各种 summary |
-| **输出** | `报告_{主题}_{时间}.md` |
-| **上游** | analysis-run Phase 4 |
-| **下游** | report-verify |
-| **依赖** | `RA:analysis-reference`（查模板）、`RA:metadata-search`（查术语） |
-
-**报告必备章节**：
-- 任务背景
-- 需求时间线
-- 报告更新时间线
-- 数据来源（位于报告上方）
-- 阶段性结论
-- 输出文件清单
-- 口径说明（本次新增/临时）附录
-- 阅读提示 / 注意事项
-- 一段话结论
-- 假设验证章节
-
-**硬约束**：追加写作（不重写）、模板以 plan 锁定结果为准、禁止报告阶段重新选模板。
-
-### RA:report-verify
-
-| 项目 | 说明 |
-| --- | --- |
-| **触发条件** | 报告交付前做质量门禁 |
-| **输入** | `data.csv` + `analysis.json` + `report.md` |
-| **输出** | `verification.json` |
-| **上游** | report + analysis-run Phase 3 + data-export |
-
-**10 项检查**：
-
-| 检查 | 说明 |
-| --- | --- |
-| evidence_completeness | 每个 finding 必须有 evidence |
-| ranking_consistency | Top/Bottom 声明与 statistics 对齐 |
-| trend_consistency | 增长/下降与 trend_label 对齐 |
-| numeric_traceability | 报告中大数字可追溯到 analysis.json 或 CSV |
-| confidence_threshold | 低置信度 finding 标记为 warning |
-| metric_definition_appendix | 报告包含口径说明附录 |
-| metric_term_consistency | 指标命名与数据字段一致 |
-| data_source_section_position | "数据来源"章节位于报告上方 |
-| data_source_display_name | 数据源展示用中文名 |
-| output_file_list_section | 报告包含输出文件清单 |
-
-**verification.json 结构** (遵循 `schemas/verification.schema.json`)：
-
-```json
-{
-  "job_id": "...",
-  "verified_at": "ISO 8601",
-  "status": "passed | failed | warning",
-  "checks": [...],
-  "summary": {
-    "total_checks": 15,
-    "passed": 12,
-    "failed": 2,
-    "warnings": 1
-  }
-}
-```
-
-### RA:artifact-fusion
-
-| 项目 | 说明 |
-| --- | --- |
-| **触发条件** | source group 内多次 export 完成后，需要合并数据集 |
-| **输入** | 多个输入目录（含 CSV + manifest） |
-| **输出** | 合并 CSV + lineage manifest |
-| **上游** | data-export（多次导出后） |
-| **下游** | data-profile → 继续分析 |
-
-**三种策略**：
-
-| 策略 | 说明 | 注意事项 |
-| --- | --- | --- |
-| `union` | 纵向拼接（schema 相同） | 自动对齐列名 |
-| `join` | 横向拼列 | ⚠️ 按索引拼列，非键 join |
-| `passthrough` | 单 source 透传 | 只更新 manifest |
-
-### RA:analysis-reference
-
-| 项目 | 说明 |
-| --- | --- |
-| **触发条件** | 需要查询报告模板或分析框架 |
-| **输入** | 关键词 + 查询类型（template / framework） |
-| **输出** | JSON 查询结果 |
-| **消费者** | analysis-plan（框架）、report（模板） |
-
-**两种查询类型**：`--template`、`--framework`
-
-**数据源**：
-- template → `skills/report/references/template-system-v2.md`
-- framework → 内置框架定义
-
-### RA:metadata-search
-
-| 项目 | 说明 |
-| --- | --- |
-| **触发条件** | 需要搜索指标、字段、术语、dataset 或 mapping 定义；或浏览数据集目录 |
-| **输入** | 关键词 + 类型（metric / field / term / dataset / mapping / all） |
-| **输出** | JSON 检索结果 + catalog 摘要 |
-| **消费者** | analysis-plan（指标/字段）、report（术语） |
-
-**六种查询类型**：`metric`、`field`、`term`、`dataset`、`mapping`、`all`
-
-**数据源**：
-- 全部类型 → `metadata/index/search.db`（FTS5）或 `metadata/index/*.jsonl`（fallback）
-
-### RA:metadata-report
-
-| 项目 | 说明 |
-| --- | --- |
-| **触发条件** | 需要生成元数据审阅报告 |
-| **输入** | dataset YAML、connector sync 产物 |
-| **输出** | Markdown 元数据报告 |
-| **独立于主链路** | 不被 analysis-run 自动调用 |
+Dashboard-oriented context 需要提供 `chart_intent`、`filter_role`、`aggregation_safety` 和 `view_model_readiness`，让 dashboard 设计从语义开始，而不是从页面组件开始。
 
 ---
 
 ## Skill 间数据契约
 
-### analysis.json（核心枢纽）
-
-`analysis.json` 是连接"分析阶段"和"验证阶段"的核心产物：
-
-```
-analysis-run Phase 3   ──→   analysis.json   ──→   report-verify
-                                    │
-                                    └──→   report（引用分析结论）
-```
-
-**Schema**: `schemas/analysis.schema.json`
-
-**必填字段**：
-- `job_id`: SESSION_ID
-- `dataset_id`: metadata dataset id
-- `created_at`: ISO 8601
-- `findings[]`: 每条分析结论
-  - `id`: `f_001` 格式递增
-  - `type`: ranking / trend / comparison / anomaly / correlation / summary
-  - `claim`: 自然语言结论
-  - `evidence`: source_file + calculation + row_indices
-  - `confidence`: 0-1
-- `statistics{}`: 聚合统计结果（verify 用于排名/趋势校验）
-
-### normalized_request.json
-
-```
-analysis-run Phase 0.1   ──→   normalized_request.json   ──→   analysis-plan
-```
-
-**必填字段**：request_type、business_goal、audience、expected_detail_level、output_preference、time_scope、confidence
-
-### export_summary.json / duckdb_export_summary.json
-
-```
-data-export   ──→   export_summary   ──→   data-profile（推导 CSV 路径）
-                                     ──→   analysis-run（确认可用数据）
-```
-
-### profile.json + manifest.json
-
-```
-data-profile   ──→   profile.json      ──→   analysis-run Phase 3（字段语义）
-                ──→   manifest.json     ──→   report（schema + lineage）
-```
+| 上游 | 下游 | 传递内容 | 契约重点 |
+| --- | --- | --- | --- |
+| `RA:metadata` | `RA:analysis-run` | context pack、dataset id、field/metric/term 语义、review 标记 | context pack 是最小上下文，不替代 YAML 真源。 |
+| `RA:analysis-run` | `RA:data-export` | 已确认 plan、dataset id、字段白名单、筛选条件、输出目录 | 正式取数必须来自确认后的计划。 |
+| `RA:data-export` | `RA:data-profile` | CSV 路径、export_summary、source lineage | 下游从 summary 或 artifact index 读实际路径。 |
+| `RA:data-profile` | `RA:analysis-run` | profile manifest、profile.json、字段质量信号 | profile 是分析证据，不写回 dataset YAML。 |
+| `RA:analysis-run` | `RA:report` | plan、profile、analysis.json、analysis_journal | 报告只使用已记录证据和明确假设。 |
+| `RA:report` | `RA:report-verify` | report.md、artifact index、analysis evidence | 验证检查结论是否可追溯。 |
+| `RA:analysis-run` | `RA:metadata-refine` | metadata feedback、profile、样本探查线索 | refine 只生成参考材料，不直接改 YAML。 |
+| `dashboard-goal-decomposer` | `dashboard-prototype-planner` | goal/chart/filter contract、open questions | 先锁分析结构，再做布局。 |
+| `dashboard-prototype-planner` | `dashboard-implementation-builder` | layout spec、view-model contract、Antigravity prompt contract | 允许 prototype 使用 mock，但实现必须替换为真实数据。 |
+| `RA:data-export` / `RA:data-profile` | `dashboard-implementation-builder` | DWD/DWS/ADS 数据、profile、quality report | dashboard readiness 需要真实数据链路和 binding audit。 |
 
 ---
 
-## 连续分析（多轮）
+## 产物归属
 
-### Job 内产物演变
-
-| 产物 | 首轮 | 后续轮次 |
-| --- | --- | --- |
-| `normalized_request.json` | 创建 | 不变 |
-| `analysis_plan.md` | 创建 | 不变（除非用户明确要求修改 plan） |
-| `data/*.csv` | 首次导出 | 可补导出（同源可直接执行，新源需确认） |
-| `analysis.json` | 创建 | 追加新 findings，id 递增 |
-| `报告_*.md` | 创建 | 追加新章节（不重写旧内容） |
-| `analysis_journal.md` | 创建 | 追加本轮日志 |
-| `user_request_timeline.md` | 创建 | 追加本轮需求 |
-| `artifact_index.json` | 创建 | 追加新产物条目 |
-| `acquisition_log.jsonl` | 创建 | 追加新导出记录 |
-
-### 数据源扩展规则
-
-| 场景 | 处理 |
+| 产物 | Owner |
 | --- | --- |
-| 补同源数据 | 直接执行，记录原因和筛选条件 |
-| source group 内新增 | plan 确认时一并通过，不需逐个确认 |
-| group 外新增数据源 | 必须先获用户确认，标记 `--is-new-source --confirmed` |
-| 合并多源 | source group 内多次 export 后调用 `RA:artifact-fusion`，再送 `RA:data-profile` |
+| dataset/dictionary/mapping YAML | `RA:metadata` |
+| metadata index、catalog、context pack | `RA:metadata` |
+| runtime registry sync | `RA:metadata` |
+| CSV、export_summary、acquisition_log | `RA:data-export` |
+| profile manifest、profile.json、quality summary | `RA:data-profile` |
+| `normalized_request.json`、`analysis_plan.md`、`analysis.json`、`analysis_journal.md` | `RA:analysis-run` |
+| Markdown report | `RA:report` |
+| `verification.json`、delivery manifest | `RA:report-verify` |
+| refine reference pack | `RA:metadata-refine` |
+| dashboard goal/chart/filter contracts | `dashboard-goal-decomposer` |
+| prototype/layout/view-model contracts | `dashboard-prototype-planner` |
+| dashboard HTML/data assets/binding audit/browser QA evidence | `dashboard-implementation-builder` |
 
 ---
 
-## 辅助 Skill 触发条件
+## 错误处理与回退
 
-### analysis-reference
-
-```
-触发点: analysis-plan Phase 3-4
-  ├── 查框架定义 → --framework <name>
-  └── 查模板配置 → --template <keyword>
-
-触发点: report Phase 4
-  └── 查模板配置 → --template <keyword>
-```
-
-### metadata-search
-
-```
-触发点: analysis-plan Phase 0.2
-  ├── 搜指标 → --type metric --query <keyword>
-  ├── 搜字段 → --type field --query <keyword>
-  └── 搜术语 → --type term --query <keyword>
-
-触发点: report Phase 4
-  └── 搜业务术语 → --type term --query <keyword>
-
-触发点: 需求理解阶段
-  └── 浏览数据集目录 → catalog [--domain <d>]
-```
-
-### artifact-fusion
-
-```
-触发条件:
-  1. analysis-plan 确定 source group（1 primary + 至多 2 supplementary）
-  2. 用户在 plan 确认时一并通过 source group
-  3. data-export 分别完成 group 内各 source 的导出
-  4. → artifact-fusion 合并 group 内数据集
-  5. → data-profile 画像合并后数据
-  6. → 继续分析
-
-  source group 持久化到 registry.db，下次相同 primary source 自动推荐已有 group。
-  查询已有 group: query_registry.py --groups [source_id]
-```
-
-### metadata-report
-
-```
-触发条件:
-  - 用户需要审阅元数据注册状态
-  - Connector sync 后需要查看同步结果
-  - 需要 review gap 报告
-
-  不在 analysis-run 主链路中, 独立调用
-```
-
----
-
-## 错误处理与降级
-
-| 错误场景 | Skill | 处理 |
+| 失败点 | 回退 owner | 处理方式 |
 | --- | --- | --- |
-| `normalized_request.json` 缺失 | analysis-plan | 编排下报错；独立调用时追问后自行生成 |
-| registry 无匹配 source | data-export | 回退到 metadata，检查注册状态 |
-| 导出 CSV 为空 | data-export | 标记数据限制，不继续分析 |
-| profile 失败 | data-profile | 分析原因 → 切换方法（采样/拆分） |
-| analysis.json 缺失 | report-verify | verify 无法运行，需先确认 Phase 3 产出 |
-| verify 失败 | report-verify | 输出失败项 → 回到 report 修正 |
-| 脚本执行失败 | 通用 | 1 次重试 → 2 次切换方法 → 标记数据限制 |
+| 找不到合适数据集或字段 | `RA:metadata` | search/catalog/context 后说明缺口；必要时做最小可分析注册。 |
+| metadata 与 runtime registry 不一致 | `RA:metadata` | 运行 validate、index、sync-registry 或 reconcile。 |
+| 取数失败 | `RA:data-export` | 检查 source id、字段白名单、filter/parameter、registry readiness。 |
+| profile 暴露质量问题 | `RA:data-profile` + `RA:analysis-run` | 在分析计划或报告中标记质量限制，必要时补导出。 |
+| 结论无法追溯 | `RA:report-verify` | 回到 analysis artifacts 补证据或降级结论强度。 |
+| 字段或指标口径待修 | `RA:metadata-refine` | 生成 refine pack，再由 `RA:metadata` 正式维护 YAML。 |
+| dashboard 模块只有视觉无绑定 | `dashboard-implementation-builder` | 回到 view model、data-slot、binding audit 和真实数据链路检查。 |
 
 ---
 
-## 产物生命周期
+## 发布前检查
 
-```mermaid
-stateDiagram-v2
-    [*] --> Created: Skill 首次创建
-    Created --> Active: 被下游 skill 消费
-    Active --> Appended: 连续分析追加内容
-    Appended --> Active: 下一轮继续消费
-    Active --> Verified: report-verify 校验通过
-    Verified --> Delivered: 交付给用户
-    Delivered --> [*]
-
-    Active --> DataLimited: 数据不足，标记限制
-    DataLimited --> Active: 补数后恢复
-```
-
-| 状态 | 适用产物 | 说明 |
-| --- | --- | --- |
-| Created | 所有产物 | 首次生成 |
-| Active | CSV、profile、analysis.json | 被下游 skill 读取 |
-| Appended | 报告、analysis.json、journal | 连续分析中追加 |
-| Verified | 报告 + verification.json | 门禁通过 |
-| Delivered | 报告 | 发送给用户 |
+| 检查项 | 通过标准 |
+| --- | --- |
+| active skillset | 文档、README、skill frontmatter 对 active/legacy 的说法一致。 |
+| legacy 迁移 | `metadata-search`、`analysis-plan`、`analysis-reference` 都有清楚迁移路径。 |
+| 共享能力 | `data-export` 和 `data-profile` 不再只描述为 analysis-run 内部阶段。 |
+| 探索边界 | 快速探索与正式分析的目录、产物、验证要求有明确区别。 |
+| dashboard 链路 | dashboard 文档体现 metadata context、共享取数、画像、binding audit 和 browser QA。 |
+| 验证证据 | 文档说明使用的验证点、通过结果和仍需源代码同步的边界。 |

--- a/docs/skill-invocation-policy.md
+++ b/docs/skill-invocation-policy.md
@@ -1,153 +1,152 @@
 # RealAnalyst Skill 调用策略
 
-本文档规定 RealAnalyst 在用户使用过程中的 skill 触发方式：什么时候由 Agent 自动进入对应 skill，什么时候只提示用户下一步，什么时候明确不调用。目标是避免用户每次都必须手动说 `/skill ...`，同时避免过度调用、重复取数或把轻量咨询误升级成完整分析流程。
+本文档规定 RealAnalyst 在用户使用过程中的 skill 触发方式：什么时候自动进入 skill，什么时候先提示用户确认，什么时候只做聊天回答或文档解释。目标是减少手动点名 skill，同时避免把轻量咨询误升级为正式分析、取数或 metadata 写回。
+
+相关架构优化背景见 [skill-architecture-optimization-20260702.md](skill-architecture-optimization-20260702.md)。
 
 ---
 
-## 1. 总原则
+## 总原则
 
 | 原则 | 说明 |
 | --- | --- |
-| 意图优先 | 先判断用户真实目标，再选择 skill；不要只靠关键词硬匹配。 |
-| 三核边界 | Metadata 管业务含义，Runtime Registry 管能不能取，Job 管本次实际用了什么。 |
-| 主入口少而稳 | 普通用户第一层只暴露 `RA:getting-started`、`RA:metadata`、`RA:analysis-run`。 |
-| 流程内自动 | `analysis-plan`、`data-export`、`data-profile`、`report`、`report-verify` 通常由 `RA:analysis-run` 自动编排，不要求用户逐个点名。 |
-| 关键动作停顿 | 正式取数、引入新 source、交付前动作必须保留确认点。 |
-| 低成本先行 | 需求理解先走 search/catalog/context，避免直接读取完整 YAML、全库扫描或直接导出。 |
-| 不把展示问题升级为治理问题 | CSV 表头、报告展示名、导出列名属于 export/report layer，不自动触发 metadata YAML 维护。 |
+| 意图优先 | 先判断用户真实目标，再选择 skill；关键词只作为辅助信号。 |
+| Source of truth 优先 | 业务口径先查 metadata，执行能力再查 registry，单次事实再查 job artifacts。 |
+| 主入口少而稳 | 普通用户优先暴露 `RA:getting-started`、`RA:metadata`、`RA:analysis-run`。 |
+| 共享能力可复用 | `RA:data-export` 和 `RA:data-profile` 可被多个流程调用，但调用方必须说明目标和输出路径。 |
+| 正式动作有确认 | 正式取数、新 source、新口径写回、交付发布前保留确认点。 |
+| 探索轻量化 | 用户只想预览数据时走探索流程，不创建正式 job。 |
+| 展示问题留在展示层 | CSV 表头、报告展示名、导出列名不自动触发 metadata YAML 维护。 |
+| Legacy 入口有迁移提示 | 旧入口可以响应，但应引导到新的 owner skill。 |
 
 ---
 
-## 2. Skill 分层与默认调用方式
+## 默认调用方式
 
 | 层级 | Skill | 默认调用方式 |
 | --- | --- | --- |
-| 第一层入口 | `RA:getting-started` | 用户不知道从哪里开始、首次安装、状态不明时自动建议或进入。 |
-| 第一层入口 | `RA:metadata` | 用户要注册/维护数据源、字段、指标、术语、口径、context 或 registry readiness 时进入。 |
-| 第一层入口 | `RA:analysis-run` | 用户要做正式分析，且 metadata / registry 已可支撑时进入。 |
-| 常见补充入口 | `RA:metadata-report` | 用户要看长期口径说明、注册说明或 review gap 报告时进入。 |
-| 常见补充入口 | `RA:metadata-refine` | 分析反馈、profile 或真实数据探查需要整理成 metadata 修正材料时进入。 |
-| 常见补充入口 | `RA:report-verify` | 用户已有报告或报告写完后，需要交付前门禁时进入。 |
-| 流程内 | `RA:analysis-plan` | 由 `RA:analysis-run` 在规划阶段调用；高级手工编排才直接调用。 |
-| 流程内 | `RA:data-export` | 由 `RA:analysis-run` 在已确认 plan 后调用；普通用户不从这里开始。 |
-| 流程内 | `RA:data-profile` | 导出后自动进入；用户手工要求“只做画像”时可直接进入。 |
-| 流程内 | `RA:report` | 分析阶段完成后由 `RA:analysis-run` 调用；用户只写既有分析报告时可直接进入。 |
-| 辅助 | `RA:metadata-search` | 低 token 检索字段/指标/术语/dataset/catalog；其它 skill 可频繁但轻量地调用。 |
-| 辅助 | `RA:analysis-reference` | 查框架和模板；仅在 planning/report 需要时调用。 |
-| 高级 | `RA:artifact-fusion` | source group 已确认且多个导出产物需要 union/join/passthrough 时调用。 |
-| 交接 | `RA:data-analytics-semantic-export` | 用户明确要把 RealAnalyst metadata 导出给 Data Analytics 复用时调用。 |
-| 兼容 | `RA:reference-lookup` | legacy compatibility only；新流程默认不用。 |
+| 第一层入口 | `RA:getting-started` | 用户不知道从哪里开始、首次安装、环境状态不明时进入。 |
+| 第一层入口 | `RA:metadata` | 注册、维护、搜索、catalog、context、registry readiness、dashboard-oriented context 时进入。 |
+| 第一层入口 | `RA:analysis-run` | 用户要求正式分析且 metadata / registry 已能支撑时进入。 |
+| 共享能力 | `RA:data-export` | 正式分析确认后、dashboard 构建、轻量探索、metadata refine 探查时调用。 |
+| 共享能力 | `RA:data-profile` | 导出后画像、dashboard 数据审计、轻量探索、metadata refine 证据整理时调用。 |
+| 分析内 | `RA:report` | 分析完成后由 `RA:analysis-run` 调用；也可用于已有分析 artifacts 的报告生成。 |
+| 分析内 | `RA:report-verify` | 报告交付前、已有报告验收、PR 或发布前质量门禁时调用。 |
+| 补充入口 | `RA:metadata-refine` | 分析反馈、真实数据探查和 profile 暴露口径问题时调用。 |
+| 仪表盘 | dashboard 三段式 | 用户明确要求 dashboard、看板、可视化 cockpit、Antigravity HTML 或绑定审计时调用。 |
+| Legacy | `RA:metadata-search` | 引导到 `RA:metadata search/catalog/context`。 |
+| Legacy | `RA:analysis-plan` | 引导到 `RA:analysis-run` Phase 0.2。 |
+| Legacy | `RA:analysis-reference` | 引导到 `analysis-run/references`。 |
 
 ---
 
-## 3. 自动调用、提示调用、不调用
-
-### 3.1 应自动进入 skill
+## 自动进入 skill
 
 | 用户意图 / 场景 | 自动进入 | 理由 |
 | --- | --- | --- |
-| “我想分析 X，已有 metadata / 数据源注册好了” | `RA:analysis-run` | 这是正式分析入口。 |
+| “我想分析 X”，并且数据源已注册 | `RA:analysis-run` | 正式分析入口，能串联 plan、export、profile、report、verify。 |
 | “帮我注册这个数据源 / 整理字段和指标口径” | `RA:metadata` | 目标是维护长期语义资产。 |
-| “这个字段是什么意思 / 有没有维护过这个指标” | `RA:metadata-search` | 只查 index，不需要进入完整 metadata 维护。 |
-| “给我看这个数据集的元数据说明” | `RA:metadata-report` | 目标是长期口径说明，不是业务分析。 |
+| “这个字段是什么意思 / 有没有这个指标 / 有哪些数据集” | `RA:metadata` | 统一入口承担 search、catalog 和 context。 |
+| “先看看数据长什么样 / 有哪些字段 / 大概质量如何” | 数据探索流程，调用 `RA:metadata`、`RA:data-export`、`RA:data-profile` | 目标是预览，不是正式分析。 |
+| “做一个 dashboard / 看板 / cockpit / 单 HTML 可视化” | dashboard 三段式 | 需要 goal、prototype、implementation 和 QA 分阶段推进。 |
 | “报告写完了，帮我检查能不能交付” | `RA:report-verify` | 目标是门禁验证。 |
-| “把这次分析中发现的口径问题整理给后续维护” | `RA:metadata-refine` | 只生成修正参考材料，不直接改 YAML。 |
+| “把分析中发现的口径问题整理给后续维护” | `RA:metadata-refine` | 生成修正参考材料，不直接改 YAML。 |
 | “把 RealAnalyst metadata 交给 Data Analytics 使用” | `RA:data-analytics-semantic-export` | 这是跨系统语义投影。 |
 
-### 3.2 应先提示用户，而不是直接执行
+---
 
-| 场景 | 处理 |
+## 先提示用户确认
+
+| 场景 | 处理方式 |
 | --- | --- |
-| 用户说“帮我看看能不能分析”但缺少对象、时间或指标 | 给出已知信息、建议方向和缺失项；不要直接创建 job。 |
-| 需要正式导出数据 | 展示计划、数据源、筛选条件和风险；等用户确认后再调用 `RA:data-export`。 |
-| 需要引入新的 source 或 source group 外的数据 | 说明为什么需要新增、会带来什么变化；等用户确认。 |
-| metadata / registry 不足但用户急着分析 | 说明缺口，建议先进入 `RA:metadata` 做最小可分析注册。 |
-| 用户只是在学习 RealAnalyst | 用 `RA:getting-started` 解释入口和准备材料，不执行取数或治理动作。 |
+| 用户只说“帮我看看能不能分析”，但缺少对象、时间或指标 | 先说明已知信息、候选方向和缺失项，不直接创建 job。 |
+| 正式分析即将取数 | 展示计划、数据源、筛选条件、字段范围和风险，等确认后再调用 `RA:data-export`。 |
+| 需要新增 source 或 source group 外的数据 | 说明为什么需要新增、会改变什么证据链，等确认后继续。 |
+| metadata / registry 不足但用户急着分析 | 说明缺口，建议先做最小可分析注册；若用户坚持，只能输出假设边界。 |
+| dashboard 仍停留在 mock 或原型阶段 | 标注 mock 证据类型，要求进入真实数据绑定和 QA 后才算 readiness。 |
+| metadata YAML 正式写回 | 先生成 refine pack 或变更说明，再由用户确认写回。 |
 
-### 3.3 明确不调用 skill
+---
+
+## 不调用 skill
 
 | 场景 | 不调用原因 |
 | --- | --- |
-| 用户只问概念、流程或文档解释 | 直接回答或指向文档；不启动正式流程。 |
+| 用户只问概念、流程或文档解释 | 直接回答或指向 docs，不启动正式流程。 |
 | 用户只要求 CSV 表头中文化、字段展示名调整 | 属于 export/report layer，不进入 metadata YAML 维护。 |
-| 用户要求任意 SQL 临时查询 | RealAnalyst 不替代临时 SQL 工具；若要纳入可复核流程，先注册 source 和 metadata。 |
-| 用户给出敏感样例值但未授权保存 | 不归档到 `metadata/sources/`；先提示脱敏或确认。 |
-| 已有 job 数据足够回答追问 | 不重复取数；复用当前 job 的数据和 profile。 |
+| 用户要求临时 SQL 试算且不需要可复核链路 | 使用普通 SQL 工具更合适；纳入 RealAnalyst 前需注册 source 和 metadata。 |
+| 用户给出敏感样例值但未授权保存 | 不归档到 `metadata/sources/`，先提示脱敏或确认。 |
+| 已有 job 数据足够回答追问 | 复用当前 job artifacts，不重复导出。 |
 
 ---
 
-## 4. 面向用户的提示方式
+## 面向用户的解释方式
 
-Agent 不应频繁向用户解释内部 skill 名称。只有在以下时机需要让用户知道：
+Agent 不需要频繁暴露内部 skill 名称。只有在进入工作流、等待确认、迁移路径、失败回退时，需要明确告诉用户当前使用哪个入口。
 
-1. **首次进入某条工作流时**：说明“我会先用 `RA:metadata-search` 找可用数据集，再用 `RA:analysis-run` 生成计划”。
-2. **需要用户确认时**：说明“确认后我会进入 `RA:data-export` 取数，再画像、分析和写报告”。
-3. **用户需要迁移工作流时**：例如从分析转到口径修正，说明“这不是继续分析，而是进入 `RA:metadata-refine` 生成修正材料”。
-4. **失败或缺口出现时**：说明应该回到哪个 owner skill 修复，而不是让用户猜。
-
-推荐话术：
+推荐表达：
 
 ```text
-我会先走轻量检索，不直接取数：先用 metadata search 找候选数据集，再生成本轮 context。等你确认分析计划后，才进入正式取数、画像、分析和报告。
+我会先走轻量 metadata 检索，不直接取数。先找候选数据集和字段口径，再生成本轮 context；等你确认分析计划后，再进入正式取数、画像、分析和报告。
 ```
 
 ```text
-这个问题属于字段展示层，不需要改 metadata YAML。我会在导出/报告阶段处理展示名，避免破坏字段 identity。
+这次只是数据探索，我会限制样本量并把产物放在临时目录。它不会创建正式 job；如果你确认要深入分析，再升级到 RA:analysis-run。
+```
+
+```text
+这个问题属于字段展示层，不需要改 metadata YAML。我会在导出或报告阶段处理展示名，避免破坏字段 identity。
+```
+
+```text
+这个 dashboard 目前只能算原型通过。最终 readiness 还需要真实数据链路、view model 绑定审计、控件覆盖和浏览器 QA 证据。
 ```
 
 ---
 
-## 5. 主工作流调用图
+## 主工作流调用图
 
 ```mermaid
 flowchart LR
     U[用户目标] --> R{意图判断}
     R -->|不知道从哪里开始| GS[RA:getting-started]
-    R -->|注册/维护语义| M[RA:metadata]
+    R -->|注册/维护/搜索语义| M[RA:metadata]
+    R -->|快速看数据| E[探索流程]
     R -->|正式分析| AR[RA:analysis-run]
-    R -->|只查字段/指标/术语| MS[RA:metadata-search]
-    R -->|看长期口径说明| MR[RA:metadata-report]
-    R -->|归档口径问题| REF[RA:metadata-refine]
+    R -->|dashboard| DG[dashboard-goal-decomposer]
     R -->|验证报告| RV[RA:report-verify]
+    R -->|归档口径问题| REF[RA:metadata-refine]
 
-    AR --> AP[RA:analysis-plan]
-    AP --> EX[RA:data-export]
-    EX --> DP[RA:data-profile]
-    DP --> A[LLM 分析]
+    E --> M
+    E --> EX[RA:data-export]
+    E --> DP[RA:data-profile]
+
+    AR --> M
+    AR --> EX
+    EX --> DP
+    DP --> A[LLM analysis]
     A --> RPT[RA:report]
     RPT --> RV
+    RV --> REF
+
+    DG --> PP[dashboard-prototype-planner]
+    PP --> BI[dashboard-implementation-builder]
+    M --> DG
+    EX --> BI
+    DP --> BI
 ```
 
 ---
 
-## 6. 扩展到非元数据 / 非数据分析流程
-
-RealAnalyst 当前最成熟的是 metadata-first 数据分析链路，但 skill 调用策略不应被写死成“只有元数据和分析”。新增工作流时按同一方法扩展：
-
-| 新工作流类型 | 设计方式 |
-| --- | --- |
-| 文档审查 | 建立“第一层入口 + 流程内 parser/verify/export”分层，避免用户点名每个子步骤。 |
-| 项目管理 | 将“需求 intake / 任务拆解 / 状态同步 / 复盘报告”拆成 owner skill 与流程内 skill。 |
-| 研究工作流 | 先设计 search/read/evidence pack，再设计 synthesis/report/verify。 |
-| 数据产品运营 | 把指标治理、用户反馈、实验分析、版本说明分层，不让单一 skill 承担全部职责。 |
-
-每个新工作流都必须回答四个问题：
-
-1. 普通用户第一层入口是什么？
-2. 哪些能力只能由流程内自动调用？
-3. 哪些节点必须等待用户确认？
-4. 产物 owner 是谁，失败时回到哪个 skill 修复？
-
----
-
-## 7. 发布前检查清单
+## 发布前检查清单
 
 | 检查项 | 通过标准 |
 | --- | --- |
-| Frontmatter description | 能清楚触发该 skill，且包含不要误触发的边界。 |
+| Frontmatter description | 能清楚触发该 skill，并说明误触发边界。 |
 | 用户入口 | 普通用户不用记住所有流程内 skill。 |
 | 自动调用 | 流程内 skill 有明确上游、下游和产物契约。 |
-| 频率控制 | search/reference 可以轻量调用；export/profile/report/verify 只在流程节点调用。 |
-| 用户解释 | 关键节点能解释为什么使用某个 skill。 |
-| 产物 owner | 每个文件能追溯到唯一 owner skill。 |
-| 失败回退 | 失败项能回到具体 skill 修复，而不是让用户重来。 |
+| 共享能力 | data-export/data-profile 的调用方、输出路径和证据类型清楚。 |
+| 频率控制 | search/context/profile 可以轻量调用；export/report/verify 只在合适节点调用。 |
+| 用户解释 | 关键节点能解释为什么进入该 skill。 |
+| 产物 owner | 每个文件能追溯到唯一 owner skill 或共享能力调用方。 |
+| 失败回退 | 失败项能回到具体 owner 修复。 |

--- a/docs/skillset-audit-report.md
+++ b/docs/skillset-audit-report.md
@@ -2,6 +2,8 @@
 
 本报告记录对 RealAnalyst 项目内 skillset、脚本、模板、交付物链路和调用策略的审查结论。审查目标不是重写所有 skill，而是确认当前 skillset 是否能够稳定支撑 metadata-first 的数据分析流程，并补齐会影响 Agent 高效调用的规则。
 
+> 维护说明：本文件保留为历史审查记录。2026-07-02 后的 active skillset、legacy 迁移和共享能力口径，以 [skill-architecture-optimization-20260702.md](skill-architecture-optimization-20260702.md)、[skill-interaction-design.md](skill-interaction-design.md) 和 [skill-invocation-policy.md](skill-invocation-policy.md) 为准。
+
 ---
 
 ## 1. 总体结论

--- a/docs/update-guide.md
+++ b/docs/update-guide.md
@@ -51,14 +51,14 @@ python3 scripts/check_release_alignment.py
 | 文档 | 了解什么 |
 | --- | --- |
 | `https://raw.githubusercontent.com/dabaige53/RealAnalyst/main/docs/architecture.md` | 三核架构（Metadata / Runtime Registry / Job）、文件职责 |
-| `https://raw.githubusercontent.com/dabaige53/RealAnalyst/main/docs/skill-interaction-design.md` | 14 个 skill 的调用关系、数据契约、运行时序 |
+| `https://raw.githubusercontent.com/dabaige53/RealAnalyst/main/docs/skill-interaction-design.md` | active skills、legacy 兼容入口、数据契约、运行时序 |
 | `https://raw.githubusercontent.com/dabaige53/RealAnalyst/main/skills/README.md` | 完整 skill 清单、后端脚本速查、目录结构 |
 | `https://raw.githubusercontent.com/dabaige53/RealAnalyst/main/docs/repository-layout.md` | 目录边界和 Git 策略 |
 | `https://raw.githubusercontent.com/dabaige53/RealAnalyst/main/skills/metadata/SKILL.md` | metadata skill 的分层模型、Core Workflow 和 Decision Rules |
 
 读完后向用户确认：「已更新插件本体并读取架构基线，准备开始逐层检查。」
 
-同时确认普通用户入口已经收口为 3 个核心入口和 3 个常见补充入口：`RA:getting-started`、`RA:metadata`、`RA:analysis-run`，以及 `RA:metadata-report`、`RA:metadata-refine`、`RA:report-verify`。`RA:analysis-plan`、`RA:data-export`、`RA:data-profile`、`RA:report` 只作为流程内能力出现；`RA:metadata-search`、`RA:artifact-fusion`、`RA:analysis-reference`、`RA:reference-lookup` 只作为辅助、高级或兼容入口出现。
+同时确认普通用户入口已经收口为 3 个核心入口和常见补充入口：`RA:getting-started`、`RA:metadata`、`RA:analysis-run`，以及 `RA:metadata-report`、`RA:metadata-refine`、`RA:report-verify`。Planning 已进入 `RA:analysis-run` Phase 0.2；`RA:data-export` 和 `RA:data-profile` 是共享能力，可由正式分析、dashboard、探索和 refine 带着明确输出路径调用。`RA:metadata-search`、`RA:analysis-plan`、`RA:analysis-reference`、`RA:reference-lookup` 只作为 legacy compatibility entrypoint 出现。
 
 ---
 
@@ -274,7 +274,7 @@ TABLEAU_PAT_SECRET=
 | `https://raw.githubusercontent.com/dabaige53/RealAnalyst/main/docs/metadata-lookup-workflow.md` | FTS5、catalog、reconcile、multi-dataset |
 | `https://raw.githubusercontent.com/dabaige53/RealAnalyst/main/docs/metadata-conversion-flow.md` | search.db、catalog、reconcile |
 | `https://raw.githubusercontent.com/dabaige53/RealAnalyst/main/docs/semantic-analysis-run.md` | 先 metadata 注册再正式分析、feedback/refine/writeback 边界 |
-| `https://raw.githubusercontent.com/dabaige53/RealAnalyst/main/skills/README.md` | 14 个 skill、入口层级、流程内 / 辅助 / 高级 / 兼容分层 |
+| `https://raw.githubusercontent.com/dabaige53/RealAnalyst/main/skills/README.md` | active skills、共享能力、legacy 兼容入口和目录分层 |
 | `https://raw.githubusercontent.com/dabaige53/RealAnalyst/main/skills/metadata/README.md` | FTS5、catalog、reconcile、multi-dataset |
 | `runtime/README.md`（目标项目） | source_groups、--groups |
 | `runtime/tableau/README.md`（目标项目） | source_groups、--groups |


### PR DESCRIPTION
## Summary

- Add a docs-first record for the 2026-07-02 RealAnalyst skill architecture optimization.
- Update skill interaction and invocation docs around the 10 active-skill model, shared data-export/data-profile capabilities, lightweight exploration, dashboard-oriented metadata context, and legacy migration paths.
- Align related docs so architecture, semantic workflow, LLM next steps, update guide, and historical audit notes point at the new skill architecture docs.

## Validation

- `python3` relative-link check for changed docs
- `git diff --check`

## Notes

This PR intentionally updates docs only. It does not copy analyst-workspace local task artifacts, generated dashboard data, or private workspace files into the public repository.
